### PR TITLE
[INTELL-767] Fix:Magic postprocessor

### DIFF
--- a/scala-interpreter/src/main/scala-2.11/org/apache/toree/kernel/interpreter/scala/ScalaInterpreterSpecific.scala
+++ b/scala-interpreter/src/main/scala-2.11/org/apache/toree/kernel/interpreter/scala/ScalaInterpreterSpecific.scala
@@ -183,13 +183,13 @@ trait ScalaInterpreterSpecific {
     *         variable does not exist
     */
   override def read(variableName: String): Option[AnyRef] = {
+
     require(iMain != null)
-    val variable = iMain.valueOfTerm(variableName)
-    if (variable == null || variable.isEmpty) None
-    else variable match {
-      case Some(v: AnyRef) => Some(v)
-      case Some(_) => None // Don't support AnyVal yet
-      case None => None
+
+    iMain.eval(variableName) match {
+      case null => None
+      case str: String if str.isEmpty => None
+      case res => Some(res)
     }
   }
 


### PR DESCRIPTION
The execution of line magics or cell magics in the modified version of Apache Toree don't show correctly its results in the notebook. 
Example:
%lsmagic
It prints the result (string) and the object where the result is included in the scala code ( in this case, Right(()) )