### PR TITLE
[LDG-994] Remove threadgroup check to allow Ignite from Intelligence

### DIFF
--- a/kernel-api/src/main/scala/org/apache/toree/security/KernelSecurityManager.scala
+++ b/kernel-api/src/main/scala/org/apache/toree/security/KernelSecurityManager.scala
@@ -123,11 +123,7 @@ class KernelSecurityManager extends SecurityManager {
     if (g == null) return
 
     val parentGroup = g.getParent
-
-    if (parentGroup != null &&
-      parentGroup.getName == RestrictedGroupName &&
-      g.getName != RestrictedGroupName)
-      throw new SecurityException("Not allowed to modify ThreadGroups!")
+    // parentGroup name check removed
   }
 
   override def checkExit(status: Int): Unit = {

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -65,7 +65,7 @@ object Dependencies {
   val sparkSql = Def.setting{ "org.apache.spark" %% "spark-sql" % sparkVersion.value } // Apache v2
   val sparkStreaming = Def.setting{ "org.apache.spark" %% "spark-streaming" % sparkVersion.value } // Apache v2
 
-  val springCore = "org.springframework" % "spring-core" % "4.1.1.RELEASE"// Apache v2
+  val springCore = "org.springframework" % "spring-core" % "4.3.18.RELEASE"// Apache v2
 
   val guava = "com.google.guava" % "guava" % "14.0.1" // Apache v2
 

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -65,7 +65,7 @@ object Dependencies {
   val sparkSql = Def.setting{ "org.apache.spark" %% "spark-sql" % sparkVersion.value } // Apache v2
   val sparkStreaming = Def.setting{ "org.apache.spark" %% "spark-streaming" % sparkVersion.value } // Apache v2
 
-  val springCore = "org.springframework" % "spring-core" % "4.3.18.RELEASE"// Apache v2
+  val springCore = "org.springframework" % "spring-core" % "4.1.1.RELEASE"// Apache v2
 
   val guava = "com.google.guava" % "guava" % "14.0.1" // Apache v2
 


### PR DESCRIPTION
- Remove thread group parent check to allow the creation of threads with a different parent. This enables calling Ignite from within a Toree notebook.

Toree developers are already considering the same:

https://issues.apache.org/jira/browse/TOREE-421

There is now an official PR:
https://github.com/apache/incubator-toree/pull/178